### PR TITLE
Update check_zones_in_sync

### DIFF
--- a/plugins/check_zones_in_sync
+++ b/plugins/check_zones_in_sync
@@ -31,6 +31,7 @@ VERSION=0.1
 
 require 'optparse'
 require 'ostruct'
+require 'celluloid/current'
 require 'celluloid/io'
 require 'timeout'
 


### PR DESCRIPTION
This change was necessary to get it running on Ubuntu 14.04 LTS
Gem versions:
nio4r (1.2.1)
celluloid-io (0.17.3)

Ruby version:
ruby1.9.1                             1.9.3.484-2ubuntu1.2                    amd64